### PR TITLE
Change use of MarkerFacecolor to markerfacolor in KNN notebook

### DIFF
--- a/Python/clustdimred/stats_clusterdimred_KNN.ipynb
+++ b/Python/clustdimred/stats_clusterdimred_KNN.ipynb
@@ -87,7 +87,7 @@
     "newpoint = 2*np.random.rand(2)-1\n",
     "\n",
     "# and plot it\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
     "fig"
    ]
   },
@@ -131,8 +131,8 @@
     "print('New data belong to group ' + str(whichgroup))\n",
     "\n",
     "# and re-plot\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor=groupcolors[whichgroup])\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor=groupcolors[whichgroup])\n",
     "ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')\n",
     "fig"
    ]

--- a/Python/clustdimred/stats_clusterdimred_KNN.ipynb
+++ b/Python/clustdimred/stats_clusterdimred_KNN.ipynb
@@ -1,196 +1,177 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "qlNyIhfsM3Hi"
-      },
-      "source": [
-        "# COURSE: Master statistics and machine learning: Intuition, Math, code\n",
-        "##### COURSE URL: udemy.com/course/statsml_x/?couponCode=202304\n",
-        "## SECTION: Clustering and dimension-reduction\n",
-        "### VIDEO: K-nearest neighbor\n",
-        "#### TEACHER: Mike X Cohen, sincxpress.com"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "WmjNjhJEM3Ho"
-      },
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "from scipy import stats\n",
-        "from sklearn.neighbors import KNeighborsClassifier"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "jw_6OceCM3Hp"
-      },
-      "outputs": [],
-      "source": [
-        "## Create data\n",
-        "\n",
-        "nPerClust = 50\n",
-        "\n",
-        "# XY centroid locations\n",
-        "A = [  1, 0 ]\n",
-        "B = [ -1, 0 ]\n",
-        "\n",
-        "# generate data\n",
-        "a = [ A[0]+np.random.randn(nPerClust) , A[1]+np.random.randn(nPerClust) ]\n",
-        "b = [ B[0]+np.random.randn(nPerClust) , B[1]+np.random.randn(nPerClust) ]\n",
-        "\n",
-        "# concatanate into a list\n",
-        "data = np.transpose( np.concatenate((a,b),axis=1) )\n",
-        "grouplabels = np.concatenate((np.zeros(nPerClust),np.ones(nPerClust)))\n",
-        "\n",
-        "# group color assignment\n",
-        "groupcolors = 'br'\n",
-        "\n",
-        "# show the data\n",
-        "fig,ax = plt.subplots(1)\n",
-        "ax.plot(data[grouplabels==0,0],data[grouplabels==0,1],'ks',markerfacecolor=groupcolors[0])\n",
-        "ax.plot(data[grouplabels==1,0],data[grouplabels==1,1],'ks',markerfacecolor=groupcolors[1])\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "tSNsvGHTM3Hq"
-      },
-      "outputs": [],
-      "source": [
-        "## compute distance matrix\n",
-        "\n",
-        "# initialize\n",
-        "distmat = np.zeros((nPerClust*2,nPerClust*2))\n",
-        "\n",
-        "# loop over elements\n",
-        "for i in range(nPerClust*2):\n",
-        "    for j in range(nPerClust*2):\n",
-        "        distmat[i,j] = np.sqrt( (data[i,0]-data[j,0])**2 + (data[i,1]-data[j,1])**2 )\n",
-        "\n",
-        "plt.imshow(distmat,vmax=4)\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "hwADoVjKM3Hr"
-      },
-      "outputs": [],
-      "source": [
-        "## create the new data point\n",
-        "\n",
-        "# random new point\n",
-        "newpoint = 2*np.random.rand(2)-1\n",
-        "\n",
-        "# and plot it\n",
-        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
-        "fig"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ZxaywvkhM3Hr"
-      },
-      "outputs": [],
-      "source": [
-        "# compute distance vector\n",
-        "distvec = np.zeros(nPerClust*2)\n",
-        "\n",
-        "for i in range(nPerClust*2):\n",
-        "    distvec[i] = np.sqrt( (data[i,0]-newpoint[0])**2 + (data[i,1]-newpoint[1])**2 )\n",
-        "\n",
-        "\n",
-        "# show the distances\n",
-        "plt.plot(distvec,'s',markerfacecolor='k')\n",
-        "plt.xlabel('Data element index')\n",
-        "plt.ylabel('Distance to new point')\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "qs2-SxW6M3Hs"
-      },
-      "outputs": [],
-      "source": [
-        "## now for the labeling\n",
-        "\n",
-        "# k parameter\n",
-        "k = 3\n",
-        "\n",
-        "# sort the distances\n",
-        "sortidx = np.argsort(distvec)\n",
-        "\n",
-        "# find the group assignment of the nearest neighbors\n",
-        "print(grouplabels[sortidx[:k]])\n",
-        "whichgroup = int( np.median(grouplabels[sortidx[:k]]) )\n",
-        "print('New data belong to group ' + str(whichgroup))\n",
-        "\n",
-        "# and re-plot\n",
-        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
-        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor=groupcolors[whichgroup])\n",
-        "ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')\n",
-        "fig"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
-        "id": "ng8LT0y0M3Hs"
-      },
-      "outputs": [],
-      "source": [
-        "## now using Python functions\n",
-        "knn = KNeighborsClassifier(n_neighbors=k, metric='euclidean')\n",
-        "knn.fit(data,grouplabels)\n",
-        "\n",
-        "whichgroupP = knn.predict(newpoint.reshape(1,-1))\n",
-        "\n",
-        "print('New data belong to group ' + str(whichgroupP[0]))"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.7.4"
-    },
-    "colab": {
-      "provenance": []
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# COURSE: Master statistics and machine learning: Intuition, Math, code\n",
+    "##### COURSE URL: udemy.com/course/statsml_x/?couponCode=202304 \n",
+    "## SECTION: Clustering and dimension-reduction\n",
+    "### VIDEO: K-nearest neighbor\n",
+    "#### TEACHER: Mike X Cohen, sincxpress.com"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from scipy import stats\n",
+    "from sklearn.neighbors import KNeighborsClassifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Create data\n",
+    "\n",
+    "nPerClust = 50\n",
+    "\n",
+    "# XY centroid locations\n",
+    "A = [  1, 0 ]\n",
+    "B = [ -1, 0 ]\n",
+    "\n",
+    "# generate data\n",
+    "a = [ A[0]+np.random.randn(nPerClust) , A[1]+np.random.randn(nPerClust) ]\n",
+    "b = [ B[0]+np.random.randn(nPerClust) , B[1]+np.random.randn(nPerClust) ]\n",
+    "\n",
+    "# concatanate into a list\n",
+    "data = np.transpose( np.concatenate((a,b),axis=1) )\n",
+    "grouplabels = np.concatenate((np.zeros(nPerClust),np.ones(nPerClust)))\n",
+    "\n",
+    "# group color assignment\n",
+    "groupcolors = 'br'\n",
+    "\n",
+    "# show the data\n",
+    "fig,ax = plt.subplots(1)\n",
+    "ax.plot(data[grouplabels==0,0],data[grouplabels==0,1],'ks',markerfacecolor=groupcolors[0])\n",
+    "ax.plot(data[grouplabels==1,0],data[grouplabels==1,1],'ks',markerfacecolor=groupcolors[1])\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## compute distance matrix\n",
+    "\n",
+    "# initialize\n",
+    "distmat = np.zeros((nPerClust*2,nPerClust*2))\n",
+    "\n",
+    "# loop over elements\n",
+    "for i in range(nPerClust*2):\n",
+    "    for j in range(nPerClust*2):\n",
+    "        distmat[i,j] = np.sqrt( (data[i,0]-data[j,0])**2 + (data[i,1]-data[j,1])**2 )\n",
+    "\n",
+    "plt.imshow(distmat,vmax=4)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## create the new data point\n",
+    "\n",
+    "# random new point\n",
+    "newpoint = 2*np.random.rand(2)-1\n",
+    "\n",
+    "# and plot it\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# compute distance vector\n",
+    "distvec = np.zeros(nPerClust*2)\n",
+    "\n",
+    "for i in range(nPerClust*2):\n",
+    "    distvec[i] = np.sqrt( (data[i,0]-newpoint[0])**2 + (data[i,1]-newpoint[1])**2 )\n",
+    "    \n",
+    "\n",
+    "# show the distances\n",
+    "plt.plot(distvec,'s',markerfacecolor='k')\n",
+    "plt.xlabel('Data element index')\n",
+    "plt.ylabel('Distance to new point')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## now for the labeling\n",
+    "\n",
+    "# k parameter\n",
+    "k = 3\n",
+    "\n",
+    "# sort the distances\n",
+    "sortidx = np.argsort(distvec)\n",
+    "\n",
+    "# find the group assignment of the nearest neighbors\n",
+    "print(grouplabels[sortidx[:k]])\n",
+    "whichgroup = int( np.median(grouplabels[sortidx[:k]]) )\n",
+    "print('New data belong to group ' + str(whichgroup))\n",
+    "\n",
+    "# and re-plot\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
+    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor=groupcolors[whichgroup])\n",
+    "ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## now using Python functions\n",
+    "knn = KNeighborsClassifier(n_neighbors=k, metric='euclidean')\n",
+    "knn.fit(data,grouplabels)\n",
+    "\n",
+    "whichgroupP = knn.predict(newpoint.reshape(1,-1))\n",
+    "\n",
+    "print('New data belong to group ' + str(whichgroupP[0]))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
 }

--- a/Python/clustdimred/stats_clusterdimred_KNN.ipynb
+++ b/Python/clustdimred/stats_clusterdimred_KNN.ipynb
@@ -1,177 +1,196 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# COURSE: Master statistics and machine learning: Intuition, Math, code\n",
-    "##### COURSE URL: udemy.com/course/statsml_x/?couponCode=202304 \n",
-    "## SECTION: Clustering and dimension-reduction\n",
-    "### VIDEO: K-nearest neighbor\n",
-    "#### TEACHER: Mike X Cohen, sincxpress.com"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "qlNyIhfsM3Hi"
+      },
+      "source": [
+        "# COURSE: Master statistics and machine learning: Intuition, Math, code\n",
+        "##### COURSE URL: udemy.com/course/statsml_x/?couponCode=202304\n",
+        "## SECTION: Clustering and dimension-reduction\n",
+        "### VIDEO: K-nearest neighbor\n",
+        "#### TEACHER: Mike X Cohen, sincxpress.com"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 1,
+      "metadata": {
+        "id": "WmjNjhJEM3Ho"
+      },
+      "outputs": [],
+      "source": [
+        "import numpy as np\n",
+        "import matplotlib.pyplot as plt\n",
+        "from scipy import stats\n",
+        "from sklearn.neighbors import KNeighborsClassifier"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "jw_6OceCM3Hp"
+      },
+      "outputs": [],
+      "source": [
+        "## Create data\n",
+        "\n",
+        "nPerClust = 50\n",
+        "\n",
+        "# XY centroid locations\n",
+        "A = [  1, 0 ]\n",
+        "B = [ -1, 0 ]\n",
+        "\n",
+        "# generate data\n",
+        "a = [ A[0]+np.random.randn(nPerClust) , A[1]+np.random.randn(nPerClust) ]\n",
+        "b = [ B[0]+np.random.randn(nPerClust) , B[1]+np.random.randn(nPerClust) ]\n",
+        "\n",
+        "# concatanate into a list\n",
+        "data = np.transpose( np.concatenate((a,b),axis=1) )\n",
+        "grouplabels = np.concatenate((np.zeros(nPerClust),np.ones(nPerClust)))\n",
+        "\n",
+        "# group color assignment\n",
+        "groupcolors = 'br'\n",
+        "\n",
+        "# show the data\n",
+        "fig,ax = plt.subplots(1)\n",
+        "ax.plot(data[grouplabels==0,0],data[grouplabels==0,1],'ks',markerfacecolor=groupcolors[0])\n",
+        "ax.plot(data[grouplabels==1,0],data[grouplabels==1,1],'ks',markerfacecolor=groupcolors[1])\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tSNsvGHTM3Hq"
+      },
+      "outputs": [],
+      "source": [
+        "## compute distance matrix\n",
+        "\n",
+        "# initialize\n",
+        "distmat = np.zeros((nPerClust*2,nPerClust*2))\n",
+        "\n",
+        "# loop over elements\n",
+        "for i in range(nPerClust*2):\n",
+        "    for j in range(nPerClust*2):\n",
+        "        distmat[i,j] = np.sqrt( (data[i,0]-data[j,0])**2 + (data[i,1]-data[j,1])**2 )\n",
+        "\n",
+        "plt.imshow(distmat,vmax=4)\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "hwADoVjKM3Hr"
+      },
+      "outputs": [],
+      "source": [
+        "## create the new data point\n",
+        "\n",
+        "# random new point\n",
+        "newpoint = 2*np.random.rand(2)-1\n",
+        "\n",
+        "# and plot it\n",
+        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
+        "fig"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ZxaywvkhM3Hr"
+      },
+      "outputs": [],
+      "source": [
+        "# compute distance vector\n",
+        "distvec = np.zeros(nPerClust*2)\n",
+        "\n",
+        "for i in range(nPerClust*2):\n",
+        "    distvec[i] = np.sqrt( (data[i,0]-newpoint[0])**2 + (data[i,1]-newpoint[1])**2 )\n",
+        "\n",
+        "\n",
+        "# show the distances\n",
+        "plt.plot(distvec,'s',markerfacecolor='k')\n",
+        "plt.xlabel('Data element index')\n",
+        "plt.ylabel('Distance to new point')\n",
+        "plt.show()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "qs2-SxW6M3Hs"
+      },
+      "outputs": [],
+      "source": [
+        "## now for the labeling\n",
+        "\n",
+        "# k parameter\n",
+        "k = 3\n",
+        "\n",
+        "# sort the distances\n",
+        "sortidx = np.argsort(distvec)\n",
+        "\n",
+        "# find the group assignment of the nearest neighbors\n",
+        "print(grouplabels[sortidx[:k]])\n",
+        "whichgroup = int( np.median(grouplabels[sortidx[:k]]) )\n",
+        "print('New data belong to group ' + str(whichgroup))\n",
+        "\n",
+        "# and re-plot\n",
+        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)\n",
+        "ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor=groupcolors[whichgroup])\n",
+        "ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')\n",
+        "fig"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "ng8LT0y0M3Hs"
+      },
+      "outputs": [],
+      "source": [
+        "## now using Python functions\n",
+        "knn = KNeighborsClassifier(n_neighbors=k, metric='euclidean')\n",
+        "knn.fit(data,grouplabels)\n",
+        "\n",
+        "whichgroupP = knn.predict(newpoint.reshape(1,-1))\n",
+        "\n",
+        "print('New data belong to group ' + str(whichgroupP[0]))"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.4"
+    },
+    "colab": {
+      "provenance": []
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "from scipy import stats\n",
-    "from sklearn.neighbors import KNeighborsClassifier"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## Create data\n",
-    "\n",
-    "nPerClust = 50\n",
-    "\n",
-    "# XY centroid locations\n",
-    "A = [  1, 0 ]\n",
-    "B = [ -1, 0 ]\n",
-    "\n",
-    "# generate data\n",
-    "a = [ A[0]+np.random.randn(nPerClust) , A[1]+np.random.randn(nPerClust) ]\n",
-    "b = [ B[0]+np.random.randn(nPerClust) , B[1]+np.random.randn(nPerClust) ]\n",
-    "\n",
-    "# concatanate into a list\n",
-    "data = np.transpose( np.concatenate((a,b),axis=1) )\n",
-    "grouplabels = np.concatenate((np.zeros(nPerClust),np.ones(nPerClust)))\n",
-    "\n",
-    "# group color assignment\n",
-    "groupcolors = 'br'\n",
-    "\n",
-    "# show the data\n",
-    "fig,ax = plt.subplots(1)\n",
-    "ax.plot(data[grouplabels==0,0],data[grouplabels==0,1],'ks',markerfacecolor=groupcolors[0])\n",
-    "ax.plot(data[grouplabels==1,0],data[grouplabels==1,1],'ks',markerfacecolor=groupcolors[1])\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## compute distance matrix\n",
-    "\n",
-    "# initialize\n",
-    "distmat = np.zeros((nPerClust*2,nPerClust*2))\n",
-    "\n",
-    "# loop over elements\n",
-    "for i in range(nPerClust*2):\n",
-    "    for j in range(nPerClust*2):\n",
-    "        distmat[i,j] = np.sqrt( (data[i,0]-data[j,0])**2 + (data[i,1]-data[j,1])**2 )\n",
-    "\n",
-    "plt.imshow(distmat,vmax=4)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## create the new data point\n",
-    "\n",
-    "# random new point\n",
-    "newpoint = 2*np.random.rand(2)-1\n",
-    "\n",
-    "# and plot it\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
-    "fig"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# compute distance vector\n",
-    "distvec = np.zeros(nPerClust*2)\n",
-    "\n",
-    "for i in range(nPerClust*2):\n",
-    "    distvec[i] = np.sqrt( (data[i,0]-newpoint[0])**2 + (data[i,1]-newpoint[1])**2 )\n",
-    "    \n",
-    "\n",
-    "# show the distances\n",
-    "plt.plot(distvec,'s',markerfacecolor='k')\n",
-    "plt.xlabel('Data element index')\n",
-    "plt.ylabel('Distance to new point')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## now for the labeling\n",
-    "\n",
-    "# k parameter\n",
-    "k = 3\n",
-    "\n",
-    "# sort the distances\n",
-    "sortidx = np.argsort(distvec)\n",
-    "\n",
-    "# find the group assignment of the nearest neighbors\n",
-    "print(grouplabels[sortidx[:k]])\n",
-    "whichgroup = int( np.median(grouplabels[sortidx[:k]]) )\n",
-    "print('New data belong to group ' + str(whichgroup))\n",
-    "\n",
-    "# and re-plot\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)\n",
-    "ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor=groupcolors[whichgroup])\n",
-    "ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')\n",
-    "fig"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "## now using Python functions\n",
-    "knn = KNeighborsClassifier(n_neighbors=k, metric='euclidean')\n",
-    "knn.fit(data,grouplabels)\n",
-    "\n",
-    "whichgroupP = knn.predict(newpoint.reshape(1,-1))\n",
-    "\n",
-    "print('New data belong to group ' + str(whichgroupP[0]))"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.4"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 2
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/Python/clustdimred/stats_clusterdimred_KNN.py
+++ b/Python/clustdimred/stats_clusterdimred_KNN.py
@@ -71,7 +71,7 @@ plt.show()
 newpoint = 2*np.random.rand(2)-1
 
 # and plot it
-ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)
+ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)
 fig
 
 
@@ -109,8 +109,8 @@ whichgroup = int( np.median(grouplabels[sortidx[:k]]) )
 print('New data belong to group ' + str(whichgroup))
 
 # and re-plot
-ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor='g',markersize=15)
-ax.plot(newpoint[0],newpoint[1],'ko',MarkerFaceColor=groupcolors[whichgroup])
+ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor='g',markersize=15)
+ax.plot(newpoint[0],newpoint[1],'ko',markerfacecolor=groupcolors[whichgroup])
 ax.plot(data[sortidx[:k],0],data[sortidx[:k],1],'ko',markersize=10,fillstyle='none')
 fig
 


### PR DESCRIPTION
Hi Mike, in the `stats_clusterdimred_KNN.ipynb` notebook, `MarkerFaceColor` isn't  an accepted parameter to [plt.plot](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.plot.html) (any longer?). Instead we need to use all lowercase, i.e. `markerfacecolor`, which is the documented parameter name since at least version 2.0 (released 2017). I'm not sure if `MarkerFaceColor` used to be an accepted alias, but if it was, I can't find any documentation of when they dropped it. Anyways, I changed `MarkerFaceColor` to `markerfacecolor` so that the notebook runs without errors on Colab.